### PR TITLE
Update HELICS GitHub repo url

### DIFF
--- a/ANL-TD-Iterative-Pflow/InstallHELICS.md
+++ b/ANL-TD-Iterative-Pflow/InstallHELICS.md
@@ -69,21 +69,21 @@ With these two dependencies installed, we are ready to install the co-simulation
 1. Download
 
 ```
-git clone https://github.com/GMLC-TDC/HELICS-src.git
+git clone https://github.com/GMLC-TDC/HELICS.git
 ```
 
 2. Install
 
-Assume <HELICS-src> is the location of the HELICS-src directory.
+Assume <HELICS> is the location of the HELICS directory.
 ```
-cd <HELICS-src>
+cd <HELICS>
 emacs ThirdParty/helics_includes/optional.hpp
 ```
-Before the line ```#define STX_NO_LIBRARY_OPTIONAL 1``` add line ```#define STX_NO_STD_OPTIONAL 1```. Save, close the file and return to HELICS-src
+Before the line ```#define STX_NO_LIBRARY_OPTIONAL 1``` add line ```#define STX_NO_STD_OPTIONAL 1```. Save, close the file and return to HELICS
 ```
 mkdir build
 cd build
-cmake .. -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=<HELICS-src>/build
+cmake .. -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=<HELICS>/build
 make
 make install
 ```
@@ -93,8 +93,8 @@ This finishes the installation of the HELICS library. Once completed, it should 
 We'll now set up some environmental that will be necessary for running the T-D dynamics co-simulation code
 ```
 emacs ~/.bashrc
-export HELICS_DIR=<HELICS-src>
-export HELICS_BUILD=<HELICS-src>/build
+export HELICS_DIR=<HELICS>
+export HELICS_BUILD=<HELICS>/build
 export LD_LIBRARY_PATH=$HELICS_BUILD/lib:$LD_LIBRARY_PATH
 export PATH=$HELICS_BUILD/bin:$PATH
 export LD_LIBRARY_PATH=$HELICS_BUILD/src/helics/shared_api_library:$LD_LIBRARY_PATH

--- a/PNNL-TD-Dynamic-Load/README.md
+++ b/PNNL-TD-Dynamic-Load/README.md
@@ -16,7 +16,7 @@ While HECLIS supports iteration at both initialization and execution stages,  in
 
 *The use case is currently developed in Linux environment, so the following instructions are only tested on Linux. Information for other development environment will be provided in the future.*
 
-1. Follow the [instructions provided by HELICS developers](https://github.com/GMLC-TDC/HELICS-src) and install HELICS **with Java binding**, which will be enabled by default installation configuration setting. You can use `ccmake .`  during the build process to check or change the configuration. 
+1. Follow the [instructions provided by HELICS developers](https://github.com/GMLC-TDC/HELICS) and install HELICS **with Java binding**, which will be enabled by default installation configuration setting. You can use `ccmake .`  during the build process to check or change the configuration. 
 
 2. Install GridLAB-D. HELICS support currently (7/14/2018) is provided in the [`feature/1024` branch](https://github.com/gridlab-d/gridlab-d/tree/feature/1024), So you need to check it out first: `git checkout -b feature/1024 origin/feature/1024`
 

--- a/PNNL-Wide-Area-Control/README.md
+++ b/PNNL-Wide-Area-Control/README.md
@@ -72,7 +72,7 @@ The same thing needs to be done for g++ by:
 `sudo update-alternatives --config g++`
 3. Build boost with gcc 4.9, as cmake will throw errors if you build HELICS with gcc 4.9 while the Boost libraries is compiled with gcc 5.x. It is recommended building and installing this version of boost with gcc 4.9 into unique location outside the system path. In this way, two version of boost compiled with different versions of gcc can be used by the two installations of HELICS. 
 4. start to build the HELICS with Matlab extension, assuming you already have Matlab installed in your Linux machine.
-  * cd to HELICS-src
+  * cd to HELICS
   * `mkdir build`
   * `cd build`
   * 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # HELICS-Use-Cases
 
-This repository contains the source code for use cases that use the Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS) tool. [Documentation and instructions](https://gmlc-tdc.github.io/HELICS-Use-Cases/index.html) are provided for each use case. HELICS source repository and installation instructions can be found [here](https://github.com/GMLC-TDC/HELICS-src/).
+This repository contains the source code for use cases that use the Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS) tool. [Documentation and instructions](https://gmlc-tdc.github.io/HELICS-Use-Cases/index.html) are provided for each use case. HELICS source repository and installation instructions can be found [here](https://github.com/GMLC-TDC/HELICS/).

--- a/docs/source/ANL-TD-Iterative-Pflow/InstallHELICS.md
+++ b/docs/source/ANL-TD-Iterative-Pflow/InstallHELICS.md
@@ -69,21 +69,21 @@ With these two dependencies installed, we are ready to install the co-simulation
 1. Download
 
 ```
-git clone https://github.com/GMLC-TDC/HELICS-src.git
+git clone https://github.com/GMLC-TDC/HELICS.git
 ```
 
 2. Install
 
-Assume <HELICS-src> is the location of the HELICS-src directory.
+Assume <HELICS> is the location of the HELICS directory.
 ```
-cd <HELICS-src>
+cd <HELICS>
 emacs ThirdParty/helics_includes/optional.hpp
 ```
-Before the line ```#define STX_NO_LIBRARY_OPTIONAL 1``` add line ```#define STX_NO_STD_OPTIONAL 1```. Save, close the file and return to HELICS-src
+Before the line ```#define STX_NO_LIBRARY_OPTIONAL 1``` add line ```#define STX_NO_STD_OPTIONAL 1```. Save, close the file and return to HELICS
 ```
 mkdir build
 cd build
-cmake .. -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=<HELICS-src>/build
+cmake .. -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=<HELICS>/build
 make
 make install
 ```
@@ -93,8 +93,8 @@ This finishes the installation of the HELICS library. Once completed, it should 
 We'll now set up some environmental that will be necessary for running the T-D dynamics co-simulation code
 ```
 emacs ~/.bashrc
-export HELICS_DIR=<HELICS-src>
-export HELICS_BUILD=<HELICS-src>/build
+export HELICS_DIR=<HELICS>
+export HELICS_BUILD=<HELICS>/build
 export LD_LIBRARY_PATH=$HELICS_BUILD/lib:$LD_LIBRARY_PATH
 export PATH=$HELICS_BUILD/bin:$PATH
 export LD_LIBRARY_PATH=$HELICS_BUILD/src/helics/shared_api_library:$LD_LIBRARY_PATH

--- a/docs/source/PNNL-Real-Time-Transactive-Energy/installation/helics.md
+++ b/docs/source/PNNL-Real-Time-Transactive-Energy/installation/helics.md
@@ -49,7 +49,7 @@ Install HELICS
 cd $HOME/repositories
 	
 # clone the HELICS repository
-git clone https://github.com/GMLC-TDC/HELICS-src.git -b HELICS_2_0
+git clone https://github.com/GMLC-TDC/HELICS.git -b HELICS_2_0
 git checkout tags/v2.0.0-beta.1
 	
 # build helics

--- a/docs/source/PNNL-TD-Dynamic-Load/index.md
+++ b/docs/source/PNNL-TD-Dynamic-Load/index.md
@@ -17,7 +17,7 @@ While HECLIS supports iteration at both initialization and execution stages,  in
 
 *The use case is currently developed in Linux environment, so the following instructions are only tested on Linux. Information for other development environment will be provided in the future.*
 
-1. Follow the [instructions provided by HELICS developers](https://github.com/GMLC-TDC/HELICS-src) and install HELICS **with Java binding**, which will be enabled by default installation configuration setting. You can use `ccmake .`  during the build process to check or change the configuration. 
+1. Follow the [instructions provided by HELICS developers](https://github.com/GMLC-TDC/HELICS) and install HELICS **with Java binding**, which will be enabled by default installation configuration setting. You can use `ccmake .`  during the build process to check or change the configuration. 
 
 2. Install GridLAB-D. HELICS support currently (7/14/2018) is provided in the [`feature/1024` branch](https://github.com/gridlab-d/gridlab-d/tree/feature/1024), So you need to check it out first: `git checkout -b feature/1024 origin/feature/1024`
 

--- a/docs/source/PNNL-Wide-Area-Control/index.md
+++ b/docs/source/PNNL-Wide-Area-Control/index.md
@@ -73,7 +73,7 @@ The same thing needs to be done for g++ by:
 `sudo update-alternatives --config g++`
 3. Build boost with gcc 4.9, as cmake will throw errors if you build HELICS with gcc 4.9 while the Boost libraries is compiled with gcc 5.x. It is recommended building and installing this version of boost with gcc 4.9 into unique location outside the system path. In this way, two version of boost compiled with different versions of gcc can be used by the two installations of HELICS. 
 4. start to build the HELICS with Matlab extension, assuming you already have Matlab installed in your Linux machine.
-  * cd to HELICS-src
+  * cd to HELICS
   * `mkdir build`
   * `cd build`
   * 


### PR DESCRIPTION
Update for the June 19, 2019 HELICS-src to HELICS repo rename.